### PR TITLE
Filter page events on initialization

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -443,6 +443,14 @@ Analytics.prototype.page = function(category, name, properties, options, fn) {
     name: name
   });
 
+  // allow enabled/disabled page calls via page options object
+  // can be done overall, or per integration
+  var plan = options.plan
+  if (plan && plan.page) {
+    if (!plan.page.enabled) return this._callback(fn);
+    defaults(msg.integrations, plan.page.integrations || {})
+  }
+
   this._invoke('page', new Page(msg));
 
   this.emit('page', category, name, properties, options);

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -445,7 +445,7 @@ Analytics.prototype.page = function(category, name, properties, options, fn) {
 
   // allow enabled/disabled page calls via page options object
   // can be done overall, or per integration
-  var plan = options.plan
+  var plan = this.options.plan || {};
   if (plan && plan.page) {
     if (!plan.page.enabled) return this._callback(fn);
     defaults(msg.integrations, plan.page.integrations || {})

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -284,6 +284,12 @@ describe('Analytics', function() {
       assert(!Test.prototype.invoke.called);
     });
 
+    it('should honor disabled integrations in page options', function() {
+      var opts = { plan: { page: { enabled: true, integrations: { Test: false } } } };
+      analytics.page('category', 'name', {}, opts);
+      assert(!Test.prototype.invoke.called);
+    });
+
     it('should emit "invoke" with facade', function(done) {
       var opts = { All: false };
       var identify = new Identify({ options: opts });
@@ -590,6 +596,22 @@ describe('Analytics', function() {
         done();
       });
       analytics.page('category', 'name', {}, {});
+    });
+
+    it('should not emit page if page is disabled', function() {
+      var opts = { plan: { page: { enabled: false } } }
+      analytics.page('category', 'name', {}, opts);
+      assert(!analytics._invoke.calledWith('page'));
+    });
+
+    it('should emit page, honoring the page options', function() {
+      var integrations = { "Google Analytics": true, "Kissmetrics": false, "Mixpanel": false }
+      var opts = { plan: { page: { enabled: true, integrations: integrations } } }
+      analytics.page('category', 'name', {}, opts);
+
+      var page = analytics._invoke.args[0][1]
+      assert.deepEqual(page.integrations(), integrations)
+      assert(analytics._invoke.calledWith('page'));
     });
   });
 


### PR DESCRIPTION
Using the `.page` options object, allows page events to be enabled/disabled either overall, or on a per-integration basis.

All page events are sent to astronomer regardless of filter.

The filter honors the root-level `enabled` boolean first, so in order to overwrite an application-level filter such as `"filter": { "page" : { "enabled" : false } }`, the options object must first enable all, then disable the integrations on an individual basis, `analytics.page(... { plan: { page: { enabled: true, integrations: { "AdWords": false, "Google Analytics": true }}}})`.

### Examples
#### Given an application with all page events enabled
```json
"filter" : {
    "page" : {
        "enabled" : true
    }
} 
```
* the following would filter all page events: 
```js
analytics.page('Pets', 'Dog Adoptions', {}, { plan: { page: { enabled: false } } });
```
* the following would filter page events to AdWords:
```js
analytics.page('Pets', 'Dog Adoptions', {}, { plan: { page: { enabled: true, integrations: { 'AdWords': false } } } });
```

#### Given an application with a filter for the AdWords integration
```json
"filter" : {
    "page" : {
        "enabled" : true, 
        "integrations" : {
            "AdWords" : false
         }
    }
} 
```
* filter all page events: 
```js
analytics.page('Pets', 'Dog Adoptions', {}, { plan: { page: { enabled: false } } });
```
* removes AdWords filter
```js
analytics.page('Pets', 'Dog Adoptions', {}, { plan: { page: { enabled: true, integrations: { 'AdWords': true } } } });
```

